### PR TITLE
Fix repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install copier
 
 ```bash
 # Generate from remote repository
-copier copy https://github.com/your-username/dev-container-template my-awesome-project
+copier copy https://github.com/pkohei/dev-container-template my-awesome-project
 
 # Generate from local template
 copier copy . /path/to/new-project


### PR DESCRIPTION
## Summary
- Updates the repository URL in README.md from a placeholder to the correct GitHub repository URL
- Ensures users can properly clone and use the template

## Changes
- Fixed repository URL in README.md from `https://github.com/your-username/dev-container-template` to `https://github.com/pkohei/dev-container-template`

🤖 Generated with [Claude Code](https://claude.ai/code)