### PR TITLE
Add configurable Node.js version support to devcontainer template

### DIFF
--- a/.devcontainer/Dockerfile.jinja
+++ b/.devcontainer/Dockerfile.jinja
@@ -25,9 +25,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 18+ for Claude Code CLI
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+# Install Node.js for Claude Code CLI
+{%- if nodejs_version == "latest" %}
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && apt-get install -y nodejs
+{%- else %}
+RUN curl -fsSL https://deb.nodesource.com/setup_{{ nodejs_version }}.x | bash - \
+    && apt-get install -y nodejs
+{%- endif %}
 
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
@@ -59,9 +64,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 18+ for Claude Code CLI
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+# Install Node.js for Claude Code CLI
+{%- if nodejs_version == "latest" %}
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && apt-get install -y nodejs
+{%- else %}
+RUN curl -fsSL https://deb.nodesource.com/setup_{{ nodejs_version }}.x | bash - \
+    && apt-get install -y nodejs
+{%- endif %}
 
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code

--- a/copier.yml
+++ b/copier.yml
@@ -31,6 +31,11 @@ python_version:
   help: "Enter the Python version for your project (e.g., 3.11, 3.12, 3.13)"
   default: "3.12"
 
+nodejs_version:
+  type: str
+  help: "Enter the Node.js version for development environment (e.g., 18, 20, 22, or 'latest' for auto-detection)"
+  default: "latest"
+
 use_cuda:
   type: bool
   help: "Enable CUDA (GPU) support?"


### PR DESCRIPTION
## Summary
- Add `nodejs_version` parameter to copier.yml template configuration
- Update devcontainer Dockerfile to support configurable Node.js versions
- Enable both specific version selection (18, 20, 22) and automatic latest LTS detection

## Changes
- **copier.yml**: Added `nodejs_version` field with default value "latest"
- **.devcontainer/Dockerfile.jinja**: Updated Node.js installation logic to use template variable
- Production environment remains unchanged (no Node.js installation)

## Test plan
- [x] Test with `nodejs_version: "latest"` (uses setup_lts.x)
- [x] Test with `nodejs_version: "18"` (uses setup_18.x) 
- [x] Test with `nodejs_version: "20"` (uses setup_20.x)
- [x] Test with `nodejs_version: "22"` (uses setup_22.x)
- [x] Verify production Dockerfile remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)