### PR TITLE
Fix npm permissions issue in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile.jinja
+++ b/.devcontainer/Dockerfile.jinja
@@ -34,8 +34,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_{{ nodejs_version }}.x | bash - 
     && apt-get install -y nodejs
 {%- endif %}
 
-# Install Claude Code CLI
+# Install Claude Code CLI globally as root
 RUN npm install -g @anthropic-ai/claude-code
+
+# Configure npm for vscode user
+RUN mkdir -p /home/vscode/.npm-global /home/vscode/.config && \
+    echo "prefix=/home/vscode/.npm-global" > /home/vscode/.npmrc && \
+    echo 'export PATH="/home/vscode/.npm-global/bin:$PATH"' >> /home/vscode/.bashrc && \
+    chown -R vscode:vscode /home/vscode/.npm-global /home/vscode/.npmrc /home/vscode/.bashrc
 
 # Create symlink for python
 RUN ln -sf /usr/bin/python3 /usr/bin/python
@@ -73,8 +79,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_{{ nodejs_version }}.x | bash - 
     && apt-get install -y nodejs
 {%- endif %}
 
-# Install Claude Code CLI
+# Install Claude Code CLI globally as root
 RUN npm install -g @anthropic-ai/claude-code
+
+# Configure npm for vscode user
+RUN mkdir -p /home/vscode/.npm-global /home/vscode/.config && \
+    echo "prefix=/home/vscode/.npm-global" > /home/vscode/.npmrc && \
+    echo 'export PATH="/home/vscode/.npm-global/bin:$PATH"' >> /home/vscode/.bashrc && \
+    chown -R vscode:vscode /home/vscode/.npm-global /home/vscode/.npmrc /home/vscode/.bashrc
 {%- endif %}
 
 # Create a non-root user

--- a/.devcontainer/Dockerfile.jinja
+++ b/.devcontainer/Dockerfile.jinja
@@ -81,17 +81,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_{{ nodejs_version }}.x | bash - 
 
 # Install Claude Code CLI globally as root
 RUN npm install -g @anthropic-ai/claude-code
+{%- endif %}
+
+# Create a non-root user
+RUN useradd -m -s /bin/bash vscode && \
+    echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Configure npm for vscode user
 RUN mkdir -p /home/vscode/.npm-global /home/vscode/.config && \
     echo "prefix=/home/vscode/.npm-global" > /home/vscode/.npmrc && \
     echo 'export PATH="/home/vscode/.npm-global/bin:$PATH"' >> /home/vscode/.bashrc && \
     chown -R vscode:vscode /home/vscode/.npm-global /home/vscode/.npmrc /home/vscode/.bashrc
-{%- endif %}
-
-# Create a non-root user
-RUN useradd -m -s /bin/bash vscode && \
-    echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 {%- if use_cuda %}
 # Set CUDA environment variables


### PR DESCRIPTION
## Summary
- Fix EACCES permission errors when running `npm install -g` in devcontainer
- Configure npm to use user-specific global directory for vscode user
- Ensure proper build order to avoid user creation issues

## Changes
- Add npm configuration for vscode user with custom global directory
- Create `.npmrc` file with `prefix=/home/vscode/.npm-global`
- Add PATH configuration in `.bashrc` for persistent shell sessions
- Fix build order: npm configuration after vscode user creation
- Ensure proper ownership of npm directories

## Test plan
- [x] Build devcontainer successfully without errors
- [x] Run `npm install -g <package>` without permission errors
- [x] Verify npm global packages are installed in user directory
- [x] Confirm PATH includes npm global bin directory

## Resolves
This fixes the npm EACCES permission denied errors that occurred when users tried to install global npm packages in the devcontainer environment.

🤖 Generated with [Claude Code](https://claude.ai/code)